### PR TITLE
docs: 為 Python 原始碼加入 Type Hints 並更新文件以符合現有程式碼 (Vibe Kanban)

### DIFF
--- a/docs/development/getting-started.md
+++ b/docs/development/getting-started.md
@@ -151,21 +151,21 @@ woow_paas_platform/
 │   ├── __init__.py               # Python package init
 │   │
 │   ├── controllers/              # HTTP endpoints
-│   │   ├── paas.py              # Main /woow endpoint & JSON API
-│   │   └── cloud_services.py    # Cloud services API endpoints
+│   │   └── paas.py              # All API endpoints (workspace, members, cloud services)
 │   │
 │   ├── models/                   # Odoo ORM models
 │   │   ├── res_config_settings.py       # PaaS settings
 │   │   ├── workspace.py                 # Workspace model
-│   │   ├── workspace_access.py          # Workspace members
+│   │   ├── workspace_access.py          # Workspace members & roles
 │   │   ├── cloud_app_template.py        # Application templates
-│   │   ├── cloud_service.py             # Deployed services
-│   │   └── paas_operator_client.py      # HTTP client for operator
+│   │   └── cloud_service.py             # Deployed services
+│   │
+│   ├── services/                  # Service layer
+│   │   └── paas_operator.py      # HTTP client for PaaS Operator
 │   │
 │   ├── views/                    # QWeb templates & XML views
 │   │   ├── paas_app.xml         # SPA entry point template
 │   │   ├── res_config_settings_views.xml
-│   │   ├── workspace_views.xml
 │   │   └── menu.xml
 │   │
 │   ├── security/                 # Access control
@@ -187,9 +187,10 @@ woow_paas_platform/
 │   │   └── scss/                # Backend SCSS
 │   │
 │   └── tests/                    # Odoo Python tests
-│       ├── test_workspace.py
-│       ├── test_cloud_service.py
-│       └── test_paas_operator_client.py
+│       ├── test_cloud_api.py            # API endpoint & controller tests
+│       ├── test_cloud_app_template.py   # CloudAppTemplate model tests
+│       ├── test_cloud_service.py        # CloudService model tests
+│       └── test_paas_operator.py        # PaaSOperatorClient HTTP client tests
 │
 ├── extra/paas-operator/          # PaaS Operator service (FastAPI)
 │   ├── src/

--- a/docs/workspace-feature-spec.md
+++ b/docs/workspace-feature-spec.md
@@ -35,6 +35,7 @@ Workspace 是 Woow PaaS Platform 的核心功能，提供多租戶工作空間�
 | `state` | Selection | ✅ | 狀態：`active`、`archived` |
 | `access_ids` | One2many | - | 存取控制記錄 |
 | `member_count` | Integer | 計算 | 成員數量（自動計算） |
+| `service_ids` | One2many | - | 已部署的 Cloud Services |
 
 **檔案位置**: `src/models/workspace.py`
 
@@ -249,9 +250,13 @@ Reactive 服務物件，管理所有 Workspace 相關 API 呼叫與狀態。
 src/
 ├── models/
 │   ├── workspace.py           # Workspace 資料模型
-│   └── workspace_access.py    # 存取控制模型
+│   ├── workspace_access.py    # 存取控制模型
+│   ├── cloud_app_template.py  # 應用程式模板
+│   └── cloud_service.py       # 已部署服務實例
 ├── controllers/
-│   └── paas.py                # API 控制器
+│   └── paas.py                # 所有 API 端點（workspace、成員、cloud services）
+├── services/
+│   └── paas_operator.py       # PaaS Operator HTTP 客戶端
 └── static/src/paas/
     ├── services/
     │   └── workspace_service.js  # 前端 API 服務

--- a/src/controllers/paas.py
+++ b/src/controllers/paas.py
@@ -1,9 +1,12 @@
+from __future__ import annotations
+
 import hashlib
 import json
 import logging
 import traceback
 import uuid
 from datetime import datetime
+from typing import Any
 
 from odoo.http import request, route, Controller
 
@@ -22,7 +25,7 @@ _logger = logging.getLogger(__name__)
 
 class PaasController(Controller):
     @route("/woow", auth="user", website=False)
-    def paas_app(self):
+    def paas_app(self) -> Any:
         """
         Render the main PaaS application page.
 
@@ -42,7 +45,7 @@ class PaasController(Controller):
     # ==================== Config API ====================
 
     @route("/api/config", auth="user", methods=["POST"], type="json")
-    def api_config(self):
+    def api_config(self) -> dict[str, Any]:
         """
         Get PaaS platform configuration for frontend.
 
@@ -65,7 +68,7 @@ class PaasController(Controller):
     # ==================== Workspace API ====================
 
     @route("/api/workspaces", auth="user", methods=["POST"], type="json")
-    def api_workspace(self, action='list', name=None, description=None, **kwargs):
+    def api_workspace(self, action: str = 'list', name: str | None = None, description: str | None = None, **kwargs: Any) -> dict[str, Any]:
         """
         Handle workspace collection operations via JSON-RPC.
 
@@ -92,7 +95,7 @@ class PaasController(Controller):
             return {'success': False, 'error': f'Unknown action: {action}'}
 
     @route("/api/workspaces/<int:workspace_id>", auth="user", methods=["POST"], type="json")
-    def api_workspace_detail(self, workspace_id, action='get', name=None, description=None, **kwargs):
+    def api_workspace_detail(self, workspace_id: int, action: str = 'get', name: str | None = None, description: str | None = None, **kwargs: Any) -> dict[str, Any]:
         """
         Handle single workspace operations via JSON-RPC.
 
@@ -121,7 +124,7 @@ class PaasController(Controller):
         else:
             return {'success': False, 'error': f'Unknown action: {action}'}
 
-    def _list_workspaces(self):
+    def _list_workspaces(self) -> dict[str, Any]:
         """
         Get all workspaces accessible by the current user.
 
@@ -172,7 +175,7 @@ class PaasController(Controller):
             'count': len(workspaces),
         }
 
-    def _create_workspace(self, name, description):
+    def _create_workspace(self, name: str | None, description: str | None) -> dict[str, Any]:
         """
         Create a new workspace with the current user as owner.
 
@@ -224,7 +227,7 @@ class PaasController(Controller):
             _logger.error("Error creating workspace: %s\n%s", str(e), traceback.format_exc())
             return {'success': False, 'error': 'An error occurred while creating the workspace. Please try again.'}
 
-    def _get_workspace(self, workspace_id):
+    def _get_workspace(self, workspace_id: int) -> dict[str, Any]:
         """
         Get detailed information for a specific workspace.
 
@@ -289,7 +292,7 @@ class PaasController(Controller):
             }
         }
 
-    def _update_workspace(self, workspace_id, name, description):
+    def _update_workspace(self, workspace_id: int, name: str | None, description: str | None) -> dict[str, Any]:
         """
         Update workspace name and/or description.
 
@@ -353,7 +356,7 @@ class PaasController(Controller):
             }
         }
 
-    def _delete_workspace(self, workspace_id):
+    def _delete_workspace(self, workspace_id: int) -> dict[str, Any]:
         """
         Archive a workspace (soft delete).
 
@@ -398,7 +401,7 @@ class PaasController(Controller):
     # ==================== Workspace Members API ====================
 
     @route("/api/workspaces/<int:workspace_id>/members", auth="user", methods=["POST"], type="json")
-    def api_workspace_members(self, workspace_id, action='list', email=None, role=None, **kwargs):
+    def api_workspace_members(self, workspace_id: int, action: str = 'list', email: str | None = None, role: str | None = None, **kwargs: Any) -> dict[str, Any]:
         """
         Handle workspace member collection operations via JSON-RPC.
 
@@ -419,7 +422,7 @@ class PaasController(Controller):
             return {'success': False, 'error': f'Unknown action: {action}'}
 
     @route("/api/workspaces/<int:workspace_id>/members/<int:access_id>", auth="user", methods=["POST"], type="json")
-    def api_workspace_member(self, workspace_id, access_id, action='update_role', role=None, **kwargs):
+    def api_workspace_member(self, workspace_id: int, access_id: int, action: str = 'update_role', role: str | None = None, **kwargs: Any) -> dict[str, Any]:
         """
         Handle individual workspace member operations via JSON-RPC.
 
@@ -439,7 +442,7 @@ class PaasController(Controller):
         else:
             return {'success': False, 'error': f'Unknown action: {action}'}
 
-    def _list_members(self, workspace_id):
+    def _list_members(self, workspace_id: int) -> dict[str, Any]:
         """
         Get all members of a workspace.
 
@@ -492,7 +495,7 @@ class PaasController(Controller):
             'count': len(members),
         }
 
-    def _invite_member(self, workspace_id, email, role):
+    def _invite_member(self, workspace_id: int, email: str | None, role: str | None) -> dict[str, Any]:
         """
         Invite a new member to a workspace by email.
 
@@ -576,7 +579,7 @@ class PaasController(Controller):
             _logger.error("Error inviting member: %s\n%s", str(e), traceback.format_exc())
             return {'success': False, 'error': 'An error occurred while inviting the member. Please try again.'}
 
-    def _update_member_role(self, workspace_id, access_id, role):
+    def _update_member_role(self, workspace_id: int, access_id: int, role: str | None) -> dict[str, Any]:
         """
         Update a workspace member's role.
 
@@ -635,7 +638,7 @@ class PaasController(Controller):
             }
         }
 
-    def _remove_member(self, workspace_id, access_id):
+    def _remove_member(self, workspace_id: int, access_id: int) -> dict[str, Any]:
         """
         Remove a member from a workspace.
 
@@ -686,7 +689,7 @@ class PaasController(Controller):
     # ==================== Cloud Templates API ====================
 
     @route("/api/cloud/templates", auth="user", methods=["POST"], type="json")
-    def api_cloud_templates(self, category=None, search=None, **kw):
+    def api_cloud_templates(self, category: str | None = None, search: str | None = None, **kw: Any) -> dict[str, Any]:
         """
         List available cloud application templates.
 
@@ -726,7 +729,7 @@ class PaasController(Controller):
         }
 
     @route("/api/cloud/templates/<int:template_id>", auth="user", methods=["POST"], type="json")
-    def api_cloud_template(self, template_id, **kw):
+    def api_cloud_template(self, template_id: int, **kw: Any) -> dict[str, Any]:
         """
         Get a single cloud application template by ID.
 
@@ -750,7 +753,7 @@ class PaasController(Controller):
             'data': self._format_template(template, include_values=True),
         }
 
-    def _format_template(self, template, include_values=False):
+    def _format_template(self, template: Any, include_values: bool = False) -> dict[str, Any]:
         """Format a template record for API response."""
         data = {
             'id': template.id,
@@ -778,7 +781,7 @@ class PaasController(Controller):
     # ==================== Cloud Services API ====================
 
     @route("/api/workspaces/<int:workspace_id>/services", auth="user", methods=["POST"], type="json")
-    def api_workspace_services(self, workspace_id, action='list', template_id=None, name=None, values=None, **kw):
+    def api_workspace_services(self, workspace_id: int, action: str = 'list', template_id: int | None = None, name: str | None = None, values: dict[str, Any] | None = None, **kw: Any) -> dict[str, Any]:
         """
         Handle cloud service operations for a workspace.
 
@@ -818,7 +821,7 @@ class PaasController(Controller):
             return {'success': False, 'error': f'Unknown action: {action}'}
 
     @route("/api/workspaces/<int:workspace_id>/services/<int:service_id>", auth="user", methods=["POST"], type="json")
-    def api_workspace_service(self, workspace_id, service_id, action='get', values=None, version=None, **kw):
+    def api_workspace_service(self, workspace_id: int, service_id: int, action: str = 'get', values: dict[str, Any] | None = None, version: str | None = None, **kw: Any) -> dict[str, Any]:
         """
         Handle operations on a specific cloud service.
 
@@ -866,7 +869,7 @@ class PaasController(Controller):
             return {'success': False, 'error': f'Unknown action: {action}'}
 
     @route("/api/workspaces/<int:workspace_id>/services/<int:service_id>/rollback", auth="user", methods=["POST"], type="json")
-    def api_service_rollback(self, workspace_id, service_id, revision=None, **kw):
+    def api_service_rollback(self, workspace_id: int, service_id: int, revision: int | None = None, **kw: Any) -> dict[str, Any]:
         """
         Rollback a service to a previous revision.
 
@@ -911,7 +914,7 @@ class PaasController(Controller):
         return self._rollback_service(service, revision)
 
     @route("/api/workspaces/<int:workspace_id>/services/<int:service_id>/revisions", auth="user", methods=["POST"], type="json")
-    def api_service_revisions(self, workspace_id, service_id, **kw):
+    def api_service_revisions(self, workspace_id: int, service_id: int, **kw: Any) -> dict[str, Any]:
         """
         Get revision history for a service.
 
@@ -946,7 +949,7 @@ class PaasController(Controller):
 
     # ==================== Cloud Service Helpers ====================
 
-    def _filter_allowed_helm_values(self, values, template):
+    def _filter_allowed_helm_values(self, values: dict[str, Any] | None, template: Any) -> dict[str, Any]:
         """
         Filter Helm values to only include keys allowed by template's value_specs.
 
@@ -1001,7 +1004,7 @@ class PaasController(Controller):
 
         return filtered
 
-    def _list_services(self, workspace):
+    def _list_services(self, workspace: Any) -> dict[str, Any]:
         """List all services in a workspace."""
         CloudService = request.env['woow_paas_platform.cloud_service']
 
@@ -1019,7 +1022,7 @@ class PaasController(Controller):
             'count': len(data),
         }
 
-    def _create_service(self, workspace, template_id, name, values):
+    def _create_service(self, workspace: Any, template_id: int | None, name: str | None, values: dict[str, Any] | None) -> dict[str, Any]:
         """Create a new cloud service."""
         if not template_id:
             return {'success': False, 'error': 'Template ID is required'}
@@ -1166,7 +1169,7 @@ class PaasController(Controller):
             _logger.error("Error creating service: %s\n%s", str(e), traceback.format_exc())
             return {'success': False, 'error': 'An error occurred while creating the service.'}
 
-    def _get_service(self, service):
+    def _get_service(self, service: Any) -> dict[str, Any]:
         """Get service details, updating status from operator if needed."""
         # Check if we need to poll operator for status
         if service.state in ['deploying', 'upgrading']:
@@ -1177,7 +1180,7 @@ class PaasController(Controller):
             'data': self._format_service(service, include_details=True),
         }
 
-    def _update_service(self, service, values, version):
+    def _update_service(self, service: Any, values: dict[str, Any] | None, version: str | None) -> dict[str, Any]:
         """Update/upgrade a service."""
         if service.state in ['pending', 'deleting', 'error']:
             return {'success': False, 'error': f'Cannot update service in {service.state} state'}
@@ -1221,7 +1224,7 @@ class PaasController(Controller):
             _logger.error("Operator error during upgrade: %s", str(e))
             return {'success': False, 'error': f'Upgrade failed: {e.detail or e.message}'}
 
-    def _delete_service(self, service):
+    def _delete_service(self, service: Any) -> dict[str, Any]:
         """Delete/uninstall a service."""
         if service.state == 'deleting':
             return {'success': False, 'error': 'Service is already being deleted'}
@@ -1273,7 +1276,7 @@ class PaasController(Controller):
             })
             return {'success': False, 'error': f'Deletion failed: {e.detail or e.message}'}
 
-    def _rollback_service(self, service, revision):
+    def _rollback_service(self, service: Any, revision: int | None) -> dict[str, Any]:
         """Rollback service to a previous revision."""
         if service.state in ['pending', 'deleting']:
             return {'success': False, 'error': f'Cannot rollback service in {service.state} state'}
@@ -1303,7 +1306,7 @@ class PaasController(Controller):
             _logger.error("Operator error during rollback: %s", str(e))
             return {'success': False, 'error': f'Rollback failed: {e.detail or e.message}'}
 
-    def _get_service_revisions(self, service):
+    def _get_service_revisions(self, service: Any) -> dict[str, Any]:
         """Get revision history for a service."""
         client = get_paas_operator_client(request.env)
         if not client:
@@ -1328,7 +1331,7 @@ class PaasController(Controller):
                 return {'success': True, 'data': []}
             return {'success': False, 'error': f'Failed to get revisions: {e.detail or e.message}'}
 
-    def _update_service_status(self, service):
+    def _update_service_status(self, service: Any) -> None:
         """Poll operator for service status and update record.
 
         Uses optimistic locking to prevent race conditions:
@@ -1413,7 +1416,7 @@ class PaasController(Controller):
         except Exception as e:
             _logger.warning("Error polling service status: %s", str(e))
 
-    def _format_service(self, service, include_details=False):
+    def _format_service(self, service: Any, include_details: bool = False) -> dict[str, Any]:
         """Format a service record for API response."""
         data = {
             'id': service.id,

--- a/src/models/workspace.py
+++ b/src/models/workspace.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import Any, Union
+
 from odoo import models, fields, api
 from odoo.exceptions import ValidationError
 import re
@@ -62,12 +66,12 @@ class Workspace(models.Model):
     )
 
     @api.depends('access_ids')
-    def _compute_member_count(self):
+    def _compute_member_count(self) -> None:
         for workspace in self:
             workspace.member_count = len(workspace.access_ids)
 
     @api.model_create_multi
-    def create(self, vals_list):
+    def create(self, vals_list: list[dict[str, Any]]) -> Workspace:
         for vals in vals_list:
             if not vals.get('slug'):
                 vals['slug'] = self._generate_slug(vals.get('name', ''))
@@ -81,7 +85,7 @@ class Workspace(models.Model):
             })
         return workspaces
 
-    def _generate_slug(self, name):
+    def _generate_slug(self, name: str) -> str:
         """Generate a URL-friendly slug from name"""
         if not name:
             return ''
@@ -96,15 +100,15 @@ class Workspace(models.Model):
             counter += 1
         return slug
 
-    def action_archive(self):
+    def action_archive(self) -> None:
         """Archive the workspace"""
         self.write({'state': 'archived'})
 
-    def action_restore(self):
+    def action_restore(self) -> None:
         """Restore archived workspace"""
         self.write({'state': 'active'})
 
-    def check_user_access(self, user=None, required_role=None):
+    def check_user_access(self, user: Any = None, required_role: str | None = None) -> Union[Any, bool]:
         """
         Check if user has access to this workspace.
 
@@ -136,7 +140,7 @@ class Workspace(models.Model):
 
         return access
 
-    def get_user_role(self, user=None):
+    def get_user_role(self, user: Any = None) -> str | None:
         """Get the role of a user in this workspace"""
         self.ensure_one()
         user = user or self.env.user

--- a/src/models/workspace_access.py
+++ b/src/models/workspace_access.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from odoo import models, fields, api
 from odoo.exceptions import ValidationError
 
@@ -76,7 +78,7 @@ class WorkspaceAccess(models.Model):
     ]
 
     @api.constrains('role', 'workspace_id')
-    def _check_owner_count(self):
+    def _check_owner_count(self) -> None:
         """Ensure each workspace has exactly one owner"""
         for access in self:
             if access.role == ROLE_OWNER:
@@ -91,7 +93,7 @@ class WorkspaceAccess(models.Model):
                         'Transfer ownership first before assigning a new owner.'
                     )
 
-    def transfer_ownership(self, new_owner_id):
+    def transfer_ownership(self, new_owner_id: int) -> None:
         """Transfer ownership to another user"""
         self.ensure_one()
         if self.role != ROLE_OWNER:
@@ -113,7 +115,7 @@ class WorkspaceAccess(models.Model):
         self.workspace_id.write({'owner_id': new_owner_id})
 
     @api.model
-    def get_role_permissions(self, role):
+    def get_role_permissions(self, role: str) -> dict[str, bool]:
         """Get permissions for a given role"""
         permissions = {
             ROLE_OWNER: {
@@ -151,7 +153,7 @@ class WorkspaceAccess(models.Model):
         }
         return permissions.get(role, {})
 
-    def get_permissions(self):
+    def get_permissions(self) -> dict[str, bool]:
         """Get permissions for this access record"""
         self.ensure_one()
         return self.get_role_permissions(self.role)


### PR DESCRIPTION
## 摘要

- **為 Python 原始碼加入 PEP 484 Type Hints**：針對 `src/` 下所有含自訂方法的檔案加入完整型別註解
- **修正文件不準確之處**：更新 4 份 docs 文件，使其與目前程式碼狀態一致

## 變更內容

### Type Hints

為所有自訂方法加入 `from __future__ import annotations` 及完整型別註解：

- **`src/controllers/paas.py`** — 25+ 個方法，使用 `dict[str, Any]`、`str | None`、`int` 等型別
- **`src/models/workspace.py`** — 7 個方法，包括 `create()`、`check_user_access()`、`get_user_role()`
- **`src/models/workspace_access.py`** — 4 個方法，包括 `transfer_ownership()`、`get_role_permissions()`

僅含欄位定義、無自訂方法的檔案已略過（`cloud_app_template.py`、`cloud_service.py`、`res_config_settings.py`）。`services/paas_operator.py` 原本就已有完整型別註解。

### 文件更新

| 檔案 | 修正內容 |
|------|---------|
| `docs/development/getting-started.md` | 移除不存在的檔案引用（`cloud_services.py`、`paas_operator_client.py`、`workspace_views.xml`）；新增 `services/` 目錄；修正測試檔案清單 |
| `docs/spec/cloud-services.md` | 移除不存在的 `k8s_cluster`/`region` 欄位；以實際 JSON-RPC 端點取代 RESTful API 規格；更新實作階段勾選狀態（Phase 0 與 Phase 1 已完成） |
| `docs/workspace-feature-spec.md` | 新增 `service_ids` 欄位至資料模型；更新檔案索引包含 cloud services 相關檔案 |
| `docs/woowtech-paas-api-specification.md` | 新增實作狀態說明；版本更新至 1.1.0；標註各 API 區段 ✅/⬜ 狀態；加入實際端點註釋；新增 Odoo Model 名稱對照表 |

## 變更原因

Python 原始碼缺少型別註解，導致 IDE 支援與靜態分析效果不佳。文件中引用了已不存在或已變更的檔案與 API 路徑（自 Cloud Services MVP 實作後），容易對新加入專案的開發者造成混淆。

## 測試計畫

- [ ] 確認 Odoo 模組載入無 import 錯誤（`-u woow_paas_platform`）
- [ ] 抽查型別註解是否與實際方法簽名一致
- [ ] 檢閱更新後的文件是否與 `src/` 目錄結構相符

---

This PR was written using [Vibe Kanban](https://vibekanban.com)