### PR TITLE
feat: add support CRUD UI - CreateProjectModal & CreateTaskModal

### DIFF
--- a/.claude/epics/support-crud-ui/34.md
+++ b/.claude/epics/support-crud-ui/34.md
@@ -1,0 +1,69 @@
+---
+name: Add createProject() to support_service.js
+status: open
+created: 2026-02-10T06:44:22Z
+updated: 2026-02-10T07:07:07Z
+github: https://github.com/WOOWTECH/odoo-addon-woow-paas-platform/issues/34
+depends_on: []
+parallel: false
+conflicts_with: [002]
+---
+
+# Task: Add createProject() to support_service.js
+
+## Description
+
+在 `support_service.js` 新增 `createProject(workspaceId, data)` 方法。目前 `createTask()` 已存在（`:213-232`），但缺少對應的 `createProject()` 方法。此方法將呼叫後端已有的 `POST /api/support/projects/<workspace_id>` with `action: 'create'`。
+
+## Acceptance Criteria
+
+- [ ] `supportService.createProject(workspaceId, { name, description })` 方法可用
+- [ ] 成功時回傳 `{ success: true, data: ProjectData }`
+- [ ] 成功時自動更新 `this.projects` 列表（將新項目插入開頭）
+- [ ] 失敗時回傳 `{ success: false, error: string }`
+- [ ] 使用 `operationLoading.createProject` 追蹤 loading 狀態
+
+## Technical Details
+
+參照既有 `createTask()` 方法模式：
+
+```javascript
+async createProject(workspaceId, data) {
+    this.operationLoading.createProject = true;
+    try {
+        const result = await jsonRpc(`/api/support/projects/${workspaceId}`, {
+            action: "create",
+            ...data,
+        });
+        if (result.success) {
+            this.projects = [result.data, ...this.projects];
+            return { success: true, data: result.data };
+        } else {
+            return { success: false, error: result.error };
+        }
+    } catch (err) {
+        return { success: false, error: err.message };
+    } finally {
+        this.operationLoading.createProject = false;
+    }
+},
+```
+
+### Files affected
+
+- `src/static/src/paas/services/support_service.js` (edit)
+
+## Dependencies
+
+- 無（後端 API 已就緒）
+
+## Effort Estimate
+
+- Size: XS
+- Hours: 0.5
+- Parallel: false（Task 002 依賴此方法）
+
+## Definition of Done
+
+- [ ] Code implemented
+- [ ] 方法簽名與 `createTask()` 一致

--- a/.claude/epics/support-crud-ui/35.md
+++ b/.claude/epics/support-crud-ui/35.md
@@ -4,7 +4,7 @@ status: open
 created: 2026-02-10T06:44:22Z
 updated: 2026-02-10T07:07:07Z
 github: https://github.com/WOOWTECH/odoo-addon-woow-paas-platform/issues/35
-depends_on: [001]
+depends_on: [34]
 parallel: true
 conflicts_with: []
 ---

--- a/.claude/epics/support-crud-ui/35.md
+++ b/.claude/epics/support-crud-ui/35.md
@@ -1,0 +1,86 @@
+---
+name: CreateProjectModal + SupportProjectsPage integration
+status: open
+created: 2026-02-10T06:44:22Z
+updated: 2026-02-10T07:07:07Z
+github: https://github.com/WOOWTECH/odoo-addon-woow-paas-platform/issues/35
+depends_on: [001]
+parallel: true
+conflicts_with: []
+---
+
+# Task: CreateProjectModal + SupportProjectsPage integration
+
+## Description
+
+建立 `CreateProjectModal` 元件並整合到 `SupportProjectsPage`。參照 `CreateWorkspaceModal` 的 props 模式（`onClose`, `onCreated`）。在 Header 右側加「+ New Project」按鈕，在 Empty State 加「Create your first project」按鈕。
+
+## Acceptance Criteria
+
+- [ ] `CreateProjectModal.js` + `CreateProjectModal.xml` 建立完成
+- [ ] Modal 包含欄位：Project Name（必填 text）、Description（選填 textarea）、Workspace（必填 select）
+- [ ] Workspace 下拉選單從 `workspaceService` 載入已有 workspace 列表
+- [ ] 必填欄位未填時顯示 inline error，不送出請求
+- [ ] 提交時顯示 loading 狀態，按鈕 disabled
+- [ ] 提交成功後呼叫 `onCreated` callback，Modal 自動關閉
+- [ ] 提交失敗顯示錯誤訊息
+- [ ] 點 backdrop / X 按鈕可關閉 Modal
+- [ ] `SupportProjectsPage` Header 右側有「+ New Project」`WoowButton`
+- [ ] `SupportProjectsPage` Empty State 有「Create your first project」`WoowButton`
+- [ ] 點擊任一按鈕皆彈出 `CreateProjectModal`
+- [ ] 建立成功後專案列表自動刷新
+
+## Technical Details
+
+### CreateProjectModal 元件
+
+```javascript
+// 參照 CreateWorkspaceModal 模式
+static props = {
+    onClose: { type: Function },
+    onCreated: { type: Function },
+};
+
+setup() {
+    this.state = useState({
+        name: "",
+        description: "",
+        workspaceId: null,
+        loading: false,
+        error: null,
+    });
+    this.workspaces = useState(workspaceService);
+    onMounted(() => workspaceService.fetchWorkspaces());
+}
+```
+
+### SupportProjectsPage 修改
+
+1. 加入 `import { CreateProjectModal }` 和 `static components` 註冊
+2. `state` 新增 `showCreateModal: false`
+3. Header `o_woow_sp_header` 加右側按鈕區
+4. Empty State 加 `WoowButton`
+5. `onProjectCreated()` callback 呼叫 `_loadProjects()` 刷新列表
+
+### Files affected
+
+- `src/static/src/paas/components/modal/CreateProjectModal.js` (create)
+- `src/static/src/paas/components/modal/CreateProjectModal.xml` (create)
+- `src/static/src/paas/pages/support-projects/SupportProjectsPage.js` (edit)
+- `src/static/src/paas/pages/support-projects/SupportProjectsPage.xml` (edit)
+
+## Dependencies
+
+- Task 001（`createProject()` 方法）
+
+## Effort Estimate
+
+- Size: S
+- Hours: 1
+- Parallel: true（與 Task 003 可並行，不衝突檔案）
+
+## Definition of Done
+
+- [ ] Modal 元件建立完成
+- [ ] 頁面 Header + Empty State 按鈕整合完成
+- [ ] Create → 列表刷新流程正常運作

--- a/.claude/epics/support-crud-ui/36.md
+++ b/.claude/epics/support-crud-ui/36.md
@@ -1,0 +1,110 @@
+---
+name: CreateTaskModal + SupportTasksPage integration
+status: open
+created: 2026-02-10T06:44:22Z
+updated: 2026-02-10T07:07:07Z
+github: https://github.com/WOOWTECH/odoo-addon-woow-paas-platform/issues/36
+depends_on: [001]
+parallel: true
+conflicts_with: []
+---
+
+# Task: CreateTaskModal + SupportTasksPage integration
+
+## Description
+
+建立 `CreateTaskModal` 元件並整合到 `SupportTasksPage`。表單欄位比 Project 多（priority, deadline），但整體模式一致。呼叫已有的 `supportService.createTask()` 方法。
+
+## Acceptance Criteria
+
+- [ ] `CreateTaskModal.js` + `CreateTaskModal.xml` 建立完成
+- [ ] Modal 包含欄位：Task Name（必填 text）、Description（選填 textarea）、Project（必填 select）、Priority（選填 select, 預設 0）、Deadline（選填 date input）
+- [ ] Project 下拉選單從 `supportService.projects` 載入（需先 fetch）
+- [ ] 必填欄位未填時顯示 inline error，不送出請求
+- [ ] 提交時顯示 loading 狀態，按鈕 disabled
+- [ ] 提交成功後呼叫 `onCreated` callback，Modal 自動關閉
+- [ ] 提交失敗顯示錯誤訊息
+- [ ] 點 backdrop / X 按鈕可關閉 Modal
+- [ ] `SupportTasksPage` Header 右側有「+ New Task」`WoowButton`
+- [ ] `SupportTasksPage` Empty State 有「Create your first task」`WoowButton`
+- [ ] 點擊任一按鈕皆彈出 `CreateTaskModal`
+- [ ] 建立成功後任務列表自動刷新（Kanban 更新）
+
+## Technical Details
+
+### CreateTaskModal 元件
+
+```javascript
+static props = {
+    onClose: { type: Function },
+    onCreated: { type: Function },
+    defaultProjectId: { type: Number, optional: true },
+};
+
+setup() {
+    this.state = useState({
+        name: "",
+        description: "",
+        projectId: this.props.defaultProjectId || null,
+        priority: "0",
+        deadline: "",
+        loading: false,
+        error: null,
+    });
+    this.supportService = useState(supportService);
+    onMounted(() => supportService.fetchAllProjects());
+}
+```
+
+### Priority 選項
+
+```javascript
+get priorityOptions() {
+    return [
+        { value: "0", label: "Low" },
+        { value: "1", label: "Normal" },
+        { value: "2", label: "High" },
+        { value: "3", label: "Urgent" },
+    ];
+}
+```
+
+### Task 建立需要 workspaceId
+
+`createTask(workspaceId, data)` 需要 `workspaceId`。從選擇的 project 反查其 `workspace_id`：
+
+```javascript
+const project = this.supportService.projects.find(p => p.id === this.state.projectId);
+const workspaceId = project?.workspace_id;
+```
+
+### SupportTasksPage 修改
+
+1. 加入 `import { CreateTaskModal }` 和 `static components` 註冊
+2. `state` 新增 `showCreateModal: false`
+3. Header `o_woow_support_tasks_header_right` 加按鈕
+4. Empty State 加 `WoowButton`
+5. `onTaskCreated()` callback 呼叫 `_loadTasks()` 刷新列表
+
+### Files affected
+
+- `src/static/src/paas/components/modal/CreateTaskModal.js` (create)
+- `src/static/src/paas/components/modal/CreateTaskModal.xml` (create)
+- `src/static/src/paas/pages/support-tasks/SupportTasksPage.js` (edit)
+- `src/static/src/paas/pages/support-tasks/SupportTasksPage.xml` (edit)
+
+## Dependencies
+
+- Task 001（`support_service.js` 需先有 project 列表可用，且 `createTask()` 已存在）
+
+## Effort Estimate
+
+- Size: S
+- Hours: 1
+- Parallel: true（與 Task 002 可並行，不衝突檔案）
+
+## Definition of Done
+
+- [ ] Modal 元件建立完成
+- [ ] 頁面 Header + Empty State 按鈕整合完成
+- [ ] Create → Kanban 刷新流程正常運作

--- a/.claude/epics/support-crud-ui/36.md
+++ b/.claude/epics/support-crud-ui/36.md
@@ -4,7 +4,7 @@ status: open
 created: 2026-02-10T06:44:22Z
 updated: 2026-02-10T07:07:07Z
 github: https://github.com/WOOWTECH/odoo-addon-woow-paas-platform/issues/36
-depends_on: [001]
+depends_on: [34]
 parallel: true
 conflicts_with: []
 ---

--- a/.claude/epics/support-crud-ui/37.md
+++ b/.claude/epics/support-crud-ui/37.md
@@ -1,0 +1,71 @@
+---
+name: Register new components in __manifest__.py and verify
+status: open
+created: 2026-02-10T06:44:22Z
+updated: 2026-02-10T07:07:07Z
+github: https://github.com/WOOWTECH/odoo-addon-woow-paas-platform/issues/37
+depends_on: [002, 003]
+parallel: false
+conflicts_with: []
+---
+
+# Task: Register new components in __manifest__.py and verify
+
+## Description
+
+將新建的 `CreateProjectModal` 和 `CreateTaskModal` 元件檔案註冊到 `__manifest__.py` 的 `woow_paas_platform.assets_paas` bundle 中，確保 Odoo 能正確載入這些 JS/XML 資源。驗證完整的 create 流程。
+
+## Acceptance Criteria
+
+- [ ] `__manifest__.py` 的 `assets_paas` bundle 包含新的 JS + XML 檔案
+- [ ] Module 更新後不報錯
+- [ ] Support Projects 頁面：點「+ New Project」→ 填表 → 提交 → 專案出現在列表
+- [ ] Support Projects 頁面：Empty State 的「Create your first project」按鈕正常運作
+- [ ] My Support Tasks 頁面：點「+ New Task」→ 填表 → 提交 → 任務出現在 Kanban
+- [ ] My Support Tasks 頁面：Empty State 的「Create your first task」按鈕正常運作
+- [ ] Modal 關閉行為正常（backdrop click, X button）
+- [ ] 表單驗證正常（必填欄位空白阻擋提交）
+
+## Technical Details
+
+### __manifest__.py 新增
+
+在 `woow_paas_platform.assets_paas` 的 JS/XML 清單中加入：
+
+```python
+'web.assets_frontend': [],
+'woow_paas_platform.assets_paas': [
+    # ... existing entries ...
+    'woow_paas_platform/static/src/paas/components/modal/CreateProjectModal.js',
+    'woow_paas_platform/static/src/paas/components/modal/CreateProjectModal.xml',
+    'woow_paas_platform/static/src/paas/components/modal/CreateTaskModal.js',
+    'woow_paas_platform/static/src/paas/components/modal/CreateTaskModal.xml',
+],
+```
+
+### 驗證步驟
+
+1. `./odoo-bin -c odoo.conf -u woow_paas_platform --stop-after-init`（或 Docker 環境用 `./scripts/test-addon.sh`）
+2. 開啟 http://localhost → `/woow` → AI Assistant → Support Projects
+3. 測試 Create Project 完整流程
+4. 返回 → My Support Tasks → 測試 Create Task 完整流程
+
+### Files affected
+
+- `src/__manifest__.py` (edit)
+
+## Dependencies
+
+- Task 002 + Task 003（所有元件檔案須先建立完成）
+
+## Effort Estimate
+
+- Size: XS
+- Hours: 0.5
+- Parallel: false（最終整合驗證）
+
+## Definition of Done
+
+- [ ] `__manifest__.py` 更新完成
+- [ ] Module 更新無錯誤
+- [ ] 兩個頁面的 Create 流程端對端驗證通過

--- a/.claude/epics/support-crud-ui/37.md
+++ b/.claude/epics/support-crud-ui/37.md
@@ -4,7 +4,7 @@ status: open
 created: 2026-02-10T06:44:22Z
 updated: 2026-02-10T07:07:07Z
 github: https://github.com/WOOWTECH/odoo-addon-woow-paas-platform/issues/37
-depends_on: [002, 003]
+depends_on: [35, 36]
 parallel: false
 conflicts_with: []
 ---

--- a/.claude/epics/support-crud-ui/epic.md
+++ b/.claude/epics/support-crud-ui/epic.md
@@ -1,0 +1,133 @@
+---
+name: support-crud-ui
+status: backlog
+created: 2026-02-10T06:42:15Z
+progress: 0%
+prd: .claude/prds/support-crud-ui.md
+github: https://github.com/WOOWTECH/odoo-addon-woow-paas-platform/issues/33
+---
+
+# Epic: Support Projects & Tasks Create UI
+
+## Overview
+
+為 Support Projects 和 My Support Tasks 兩個既有頁面補齊 **Create** 功能。後端 API 已完整支援 CRUD，前端 `supportService` 也已有 `createTask()` 方法，本 Epic 只需：
+
+1. 新增 `createProject()` service 方法
+2. 建立兩個 Create Modal 元件（參照 `CreateWorkspaceModal` 模式）
+3. 在兩個頁面加入 Header 按鈕 + Empty State 引導按鈕
+
+影響範圍小、風險低，所有基礎設施已就緒。
+
+## Architecture Decisions
+
+| 決策 | 選擇 | 理由 |
+|------|------|------|
+| Modal 元件模式 | 參照 `CreateWorkspaceModal` 的 `onClose/onCreated` props | 與現有 codebase 一致，零學習成本 |
+| 表單驗證 | 前端 inline validation | 簡單表單，不需要額外驗證框架 |
+| Workspace/Project 下拉 | 從已有 service 載入 | `workspaceService` 和 `supportService` 已提供資料源 |
+| 不共用 Generic Modal | 分別建 `CreateProjectModal` + `CreateTaskModal` | 表單欄位差異大，分開更清楚，避免過度抽象 |
+
+## Technical Approach
+
+### Frontend — Modal 元件
+
+兩個 Modal 遵循相同模式（與 `CreateWorkspaceModal` 一致）：
+
+```
+CreateProjectModal
+├── props: { onClose, onCreated }
+├── state: { name, description, workspaceId, loading, error }
+├── onMounted → 載入 workspace 列表
+└── onSubmit → supportService.createProject()
+
+CreateTaskModal
+├── props: { onClose, onCreated, defaultProjectId? }
+├── state: { name, description, projectId, priority, deadline, loading, error }
+├── onMounted → 載入 project 列表
+└── onSubmit → supportService.createTask()
+```
+
+### Frontend — 頁面修改
+
+兩個頁面的修改模式一致：
+1. 加入 `showCreateModal` state
+2. Header 右側加 `WoowButton`（「+ New Project」/「+ New Task」）
+3. Empty State 加 `WoowButton`（「Create your first project」/「Create your first task」）
+4. 加入 `onCreated` callback 重新載入列表
+
+### Frontend — Service 擴充
+
+`support_service.js` 新增 `createProject(workspaceId, data)` 方法，模式與既有 `createTask()` 相同。
+
+### Backend
+
+不需任何後端改動。API 已就緒：
+- `POST /api/support/projects/<workspace_id>` with `action: 'create'`
+- `POST /api/support/tasks/<workspace_id>` with `action: 'create'`
+
+## Implementation Strategy
+
+**單一階段交付** — 所有改動在前端且相互關聯，一次完成：
+
+1. 先擴充 `support_service.js`（加 `createProject()`）
+2. 建立兩個 Modal 元件
+3. 修改兩個頁面（加按鈕 + 整合 Modal）
+4. 更新 `__manifest__.py` 註冊新檔案
+5. 手動測試完整 create 流程
+
+## Task Breakdown Preview
+
+- [ ] Task 1: `support_service.js` 新增 `createProject()` 方法
+- [ ] Task 2: `CreateProjectModal` 元件（JS + XML）+ `SupportProjectsPage` 整合（Header 按鈕 + Empty State 按鈕）
+- [ ] Task 3: `CreateTaskModal` 元件（JS + XML）+ `SupportTasksPage` 整合（Header 按鈕 + Empty State 按鈕）
+- [ ] Task 4: 更新 `__manifest__.py` 註冊新元件 + 手動驗證
+
+## Dependencies
+
+### Internal
+- `CreateWorkspaceModal`（設計模式參考）
+- `workspaceService`（Workspace 列表資料源）
+- `supportService`（Project 列表資料源 + API 呼叫）
+- 後端 `_create_project()` / `_create_task()`（已實作）
+
+### External
+- 無
+
+## Success Criteria (Technical)
+
+| Criteria | Target |
+|----------|--------|
+| Create Project 流程 | 填表 → 提交 → 新專案出現在列表，< 3 秒 |
+| Create Task 流程 | 填表 → 提交 → 新任務出現在 Kanban，< 3 秒 |
+| 表單驗證 | 必填欄位空白時阻擋提交並顯示錯誤 |
+| Loading 狀態 | 提交期間按鈕 disabled + loading indicator |
+| 錯誤處理 | API 失敗顯示具體錯誤訊息 |
+| Modal 行為 | 點 backdrop / X 按鈕可關閉，ESC 鍵可關閉 |
+
+## Tasks Created
+
+- [ ] #34 - Add createProject() to support_service.js (parallel: false)
+- [ ] #35 - CreateProjectModal + SupportProjectsPage integration (parallel: true)
+- [ ] #36 - CreateTaskModal + SupportTasksPage integration (parallel: true)
+- [ ] #37 - Register new components in __manifest__.py and verify (parallel: false)
+
+Total tasks: 4
+Parallel tasks: 2 (#35, #36 can run simultaneously after #34)
+Sequential tasks: 2 (#34 first, #37 last)
+Estimated total effort: 3 hours
+
+### Dependency Graph
+
+```
+#34 (createProject service)
+ ├── #35 (Project Modal + Page)  ─┐
+ └── #36 (Task Modal + Page)     ─┴── #37 (manifest + verify)
+```
+
+## Estimated Effort
+
+- **Overall**: S（Small）
+- **Tasks**: 4 個
+- **預估工時**: 2-3 小時
+- **Critical Path**: #34 → (#35 || #36) → #37

--- a/.claude/epics/support-crud-ui/github-mapping.md
+++ b/.claude/epics/support-crud-ui/github-mapping.md
@@ -1,0 +1,14 @@
+# GitHub Issue Mapping
+
+Epic: #33 - https://github.com/WOOWTECH/odoo-addon-woow-paas-platform/issues/33
+
+## Tasks
+
+| File | Issue | Title |
+|------|-------|-------|
+| 34.md | #34 | Add createProject() to support_service.js |
+| 35.md | #35 | CreateProjectModal + SupportProjectsPage integration |
+| 36.md | #36 | CreateTaskModal + SupportTasksPage integration |
+| 37.md | #37 | Register new components in __manifest__.py and verify |
+
+Synced: 2026-02-10T07:07:11Z

--- a/.claude/prds/support-crud-ui.md
+++ b/.claude/prds/support-crud-ui.md
@@ -1,0 +1,215 @@
+---
+name: support-crud-ui
+description: 為 Support Projects 和 My Support Tasks 頁面新增建立（Create）功能的 UI，包含 Modal 表單、前端 service 方法、以及 Empty State 引導。
+status: backlog
+created: 2026-02-10T06:36:06Z
+updated: 2026-02-10T06:36:06Z
+---
+
+# PRD: Support Projects & Tasks Create UI
+
+## Executive Summary
+
+目前 Support Projects 和 My Support Tasks 兩個頁面為**純唯讀瀏覽**模式，使用者無法在 `/woow` 前台建立新專案或新任務。後端 API 已支援 `create` action，前端 `support_service.js` 也已有 `createTask()` 方法，但 UI 層完全缺少建立入口。
+
+本 PRD 旨在補齊這兩個頁面的 CRUD 中的 **Create** 功能，讓使用者可以直接在前台完成專案和任務的建立操作。
+
+## Problem Statement
+
+### 現狀問題
+
+1. Support Projects 頁面（`#/ai-assistant/projects`）**沒有「New Project」按鈕**，Empty State 僅顯示提示文字
+2. My Support Tasks 頁面（`#/ai-assistant/tasks`）**沒有「New Task」按鈕**，Empty State 提示使用者去建立 Project 但沒有實際操作入口
+3. 使用者若要建立 Project 或 Task，需切換到 Odoo 後台操作，體驗斷裂
+4. 後端 API 和前端 Service 已具備 create 能力，僅差 UI 層整合
+
+### 為什麼現在做
+
+- 兩個頁面的 UI 和 API 都已就緒，缺的只是「最後一哩路」的建立表單
+- 不補齊 Create 功能，這兩個頁面對使用者而言形同擺設
+- 實作成本低（參考既有的 `CreateWorkspaceModal` 模式即可）
+
+## User Stories
+
+### US-001: 在前台建立 Support Project
+
+**作為** Workspace 成員，**我想要** 在 Support Projects 頁面直接建立新專案，**以便** 不需要切換到 Odoo 後台。
+
+**驗收標準**：
+- [ ] Support Projects Header 右側有「New Project」按鈕
+- [ ] 點擊按鈕彈出 Modal 表單
+- [ ] 表單欄位：Project Name（必填）、Description（選填）、Workspace（必填下拉選單）
+- [ ] 提交成功後，新專案即時出現在列表中
+- [ ] 提交失敗時顯示錯誤訊息
+- [ ] Empty State 增加「Create your first project」按鈕，同樣觸發 Modal
+
+### US-002: 在前台建立 Support Task
+
+**作為** Workspace 成員，**我想要** 在 My Support Tasks 頁面直接建立新任務，**以便** 快速建立待辦事項。
+
+**驗收標準**：
+- [ ] My Support Tasks Header 右側有「New Task」按鈕
+- [ ] 點擊按鈕彈出 Modal 表單
+- [ ] 表單欄位：Task Name（必填）、Description（選填）、Project（必填下拉選單）、Priority（選填）、Deadline（選填）
+- [ ] 提交成功後，新任務即時出現在 Kanban 對應的 Project 欄位中
+- [ ] 提交失敗時顯示錯誤訊息
+- [ ] Empty State 增加「Create your first task」按鈕，同樣觸發 Modal
+
+## Requirements
+
+### Functional Requirements
+
+#### FR-1: Create Project Modal
+
+- **FR-1.1**: Header 右側新增 `WoowButton`「+ New Project」
+- **FR-1.2**: Modal 元件 `CreateProjectModal`，參考 `CreateWorkspaceModal` 的 props 模式（`onClose`, `onCreated`）
+- **FR-1.3**: 表單欄位：
+  | 欄位 | 類型 | 必填 | 說明 |
+  |------|------|------|------|
+  | name | text input | Y | 專案名稱 |
+  | description | textarea | N | 專案描述 |
+  | workspace_id | select dropdown | Y | 所屬 Workspace（從已有 workspace 列表載入） |
+- **FR-1.4**: 呼叫 `POST /api/support/projects/<workspace_id>` with `action: 'create'`
+- **FR-1.5**: 成功後呼叫 `onCreated` callback，重新整理專案列表
+- **FR-1.6**: Empty State 新增「Create your first project」`WoowButton`，點擊觸發同一個 Modal
+
+#### FR-2: Create Task Modal
+
+- **FR-2.1**: Header 右側新增 `WoowButton`「+ New Task」
+- **FR-2.2**: Modal 元件 `CreateTaskModal`，同樣使用 `onClose`, `onCreated` props
+- **FR-2.3**: 表單欄位：
+  | 欄位 | 類型 | 必填 | 說明 |
+  |------|------|------|------|
+  | name | text input | Y | 任務標題 |
+  | description | textarea | N | 任務描述 |
+  | project_id | select dropdown | Y | 所屬專案（從已有 project 列表載入） |
+  | priority | select / radio | N | 優先級（0=Low, 1=Normal, 2=High, 3=Urgent），預設 0 |
+  | date_deadline | date input | N | 截止日期 |
+- **FR-2.4**: 呼叫 `supportService.createTask(workspaceId, data)`（已存在的方法）
+- **FR-2.5**: 成功後重新整理任務列表
+- **FR-2.6**: Empty State 新增「Create your first task」`WoowButton`
+
+#### FR-3: support_service.js 擴充
+
+- **FR-3.1**: 新增 `createProject(workspaceId, data)` 方法（目前缺少）
+- **FR-3.2**: `createTask()` 已存在，無需修改
+
+### Non-Functional Requirements
+
+- **NFR-1**: Modal 開啟/關閉動畫須與現有 Modal（如 `CreateWorkspaceModal`）一致
+- **NFR-2**: 表單提交時顯示 loading 狀態，防止重複提交
+- **NFR-3**: SCSS 命名遵循 `o_woow_` prefix 慣例
+- **NFR-4**: 在各螢幕尺寸下 Modal 需正常顯示（響應式）
+
+## Technical Architecture
+
+### 現有基礎設施（已就緒）
+
+| 層級 | 狀態 | 說明 |
+|------|------|------|
+| 後端 API（Project Create） | ✅ 已有 | `ai_assistant.py:497-500` — `_create_project(workspace, kwargs)` |
+| 後端 API（Task Create） | ✅ 已有 | `ai_assistant.py:535-538` — `_create_task(workspace, kwargs)` |
+| 前端 Service（Task Create） | ✅ 已有 | `support_service.js:213-232` — `createTask()` |
+| 前端 Service（Project Create） | ❌ 缺少 | 需新增 `createProject()` 方法 |
+| UI — Create Project Modal | ❌ 缺少 | 需新增元件 |
+| UI — Create Task Modal | ❌ 缺少 | 需新增元件 |
+| UI — Header 按鈕 | ❌ 缺少 | 兩個頁面都需加按鈕 |
+| UI — Empty State 按鈕 | ❌ 缺少 | 兩個頁面都需加按鈕 |
+
+### 需要新增/修改的檔案
+
+| 檔案 | 操作 | 說明 |
+|------|------|------|
+| `src/static/src/paas/components/modal/CreateProjectModal.js` | create | Modal 元件 JS |
+| `src/static/src/paas/components/modal/CreateProjectModal.xml` | create | Modal 元件 Template |
+| `src/static/src/paas/components/modal/CreateTaskModal.js` | create | Modal 元件 JS |
+| `src/static/src/paas/components/modal/CreateTaskModal.xml` | create | Modal 元件 Template |
+| `src/static/src/paas/pages/support-projects/SupportProjectsPage.js` | edit | 加入 Modal 狀態、按鈕 handler |
+| `src/static/src/paas/pages/support-projects/SupportProjectsPage.xml` | edit | Header 加按鈕、Empty State 加按鈕 |
+| `src/static/src/paas/pages/support-tasks/SupportTasksPage.js` | edit | 加入 Modal 狀態、按鈕 handler |
+| `src/static/src/paas/pages/support-tasks/SupportTasksPage.xml` | edit | Header 加按鈕、Empty State 加按鈕 |
+| `src/static/src/paas/services/support_service.js` | edit | 新增 `createProject()` 方法 |
+| `src/__manifest__.py` | edit | 註冊新元件檔案（如果需要） |
+
+### 元件架構
+
+```
+CreateProjectModal (new)
+├── props: { onClose: Function, onCreated: Function }
+├── state: { name, description, workspaceId, loading, error }
+├── 載入 workspace 列表（從 workspaceService）
+└── 呼叫 supportService.createProject()
+
+CreateTaskModal (new)
+├── props: { onClose: Function, onCreated: Function, defaultProjectId?: Number }
+├── state: { name, description, projectId, priority, deadline, loading, error }
+├── 載入 project 列表（從 supportService）
+└── 呼叫 supportService.createTask()
+```
+
+### API 呼叫
+
+**Create Project**:
+```javascript
+// support_service.js — 新增方法
+async createProject(workspaceId, { name, description }) {
+    const result = await jsonRpc(`/api/support/projects/${workspaceId}`, {
+        action: "create",
+        name,
+        description,
+    });
+    // ...
+}
+```
+
+**Create Task**（已存在）:
+```javascript
+// support_service.js:213 — 已有此方法
+await supportService.createTask(workspaceId, {
+    name, description, project_id, priority, date_deadline
+});
+```
+
+## Success Criteria
+
+| Metric | Target |
+|--------|--------|
+| 建立 Project 流程 | 從點擊按鈕到專案出現在列表 < 3 秒 |
+| 建立 Task 流程 | 從點擊按鈕到任務出現在 Kanban < 3 秒 |
+| 表單驗證 | 必填欄位未填時顯示錯誤，不送出請求 |
+| 錯誤處理 | API 失敗時顯示明確錯誤訊息 |
+
+## Constraints & Assumptions
+
+### 技術限制
+
+- Modal 設計參照 `CreateWorkspaceModal` 現有模式，不引入新的 UI 框架
+- Workspace 下拉選單的資料來源為 `workspaceService`（已有）
+- Project 下拉選單的資料來源為 `supportService.projects`（已有）
+
+### 假設
+
+- 使用者至少有一個 Workspace 才能建立 Project
+- 使用者至少有一個 Project 才能建立 Task
+- 後端 `_create_project()` 和 `_create_task()` 已正確實作並可正常運作
+
+## Out of Scope
+
+1. **編輯（Update）UI** — 本 PRD 僅涵蓋 Create，Update/Delete UI 留待後續
+2. **批次建立** — 一次只建一個 Project 或 Task
+3. **拖曳排序** — Kanban 的拖曳排序功能不在本次範圍
+4. **進階表單欄位** — 如 Assignee 指派、Tags、Milestone 等進階欄位留待後續
+5. **表單中直接建立 Workspace / Project** — 如果下拉選單為空，只引導使用者先去建立
+
+## Dependencies
+
+### Internal Dependencies
+
+- `CreateWorkspaceModal` 元件模式（作為參考）
+- `workspaceService`（提供 Workspace 列表給 Project Modal）
+- `supportService`（提供 Project 列表給 Task Modal + API 呼叫）
+- 後端 `ai_assistant.py` 的 `_create_project()` 和 `_create_task()`
+
+### External Dependencies
+
+- 無

--- a/src/controllers/ai_assistant.py
+++ b/src/controllers/ai_assistant.py
@@ -609,6 +609,9 @@ class AiAssistantController(Controller):
                 'name': project.name,
                 'description': project.description or '',
                 'workspace_id': workspace.id,
+                'workspace_name': workspace.name,
+                'task_count': 0,
+                'created_date': project.create_date.isoformat() if project.create_date else None,
             },
         }
 

--- a/src/controllers/ai_assistant.py
+++ b/src/controllers/ai_assistant.py
@@ -694,6 +694,11 @@ class AiAssistantController(Controller):
             'description': (params.get('description') or '').strip(),
         }
 
+        if params.get('priority'):
+            vals['priority'] = str(params['priority'])
+        if params.get('date_deadline'):
+            vals['date_deadline'] = params['date_deadline']
+
         if params.get('chat_enabled'):
             vals['chat_enabled'] = True
             vals['ai_auto_reply'] = params.get('ai_auto_reply', True)

--- a/src/controllers/ai_assistant.py
+++ b/src/controllers/ai_assistant.py
@@ -580,6 +580,8 @@ class AiAssistantController(Controller):
             'id': proj.id,
             'name': proj.name,
             'description': proj.description or '',
+            'workspace_id': proj.workspace_id.id if proj.workspace_id else None,
+            'workspace_name': proj.workspace_id.name if proj.workspace_id else '',
             'task_count': proj.task_count,
             'created_date': proj.create_date.isoformat() if proj.create_date else None,
         } for proj in projects]

--- a/src/static/src/paas/components/button/WoowButton.js
+++ b/src/static/src/paas/components/button/WoowButton.js
@@ -7,10 +7,12 @@ export class WoowButton extends Component {
         variant: { type: String, optional: true }, // primary, secondary, ghost
         size: { type: String, optional: true }, // sm, md, lg
         onClick: { type: Function, optional: true },
+        disabled: { type: Boolean, optional: true },
         slots: { type: Object, optional: true },
     };
 
     handleClick() {
+        if (this.props.disabled) return;
         if (this.props.onClick) {
             this.props.onClick();
         }

--- a/src/static/src/paas/components/button/WoowButton.xml
+++ b/src/static/src/paas/components/button/WoowButton.xml
@@ -2,7 +2,8 @@
 <templates xml:space="preserve">
     <t t-name="woow_paas_platform.WoowButton">
         <button t-att-class="'o_woow_btn o_woow_btn_' + (props.variant || 'primary') + ' o_woow_btn_' + (props.size || 'md')"
-                t-on-click="handleClick">
+                t-on-click="handleClick"
+                t-att-disabled="props.disabled">
             <t t-slot="default"/>
         </button>
     </t>

--- a/src/static/src/paas/components/modal/CreateProjectModal.js
+++ b/src/static/src/paas/components/modal/CreateProjectModal.js
@@ -17,16 +17,14 @@ export class CreateProjectModal extends Component {
         this.state = useState({
             name: "",
             description: "",
-            workspaceId: "",
+            workspaceId: null,
             loading: false,
             error: null,
             workspaces: [],
             workspacesLoading: true,
         });
 
-        onMounted(async () => {
-            await this._loadWorkspaces();
-        });
+        onMounted(() => this._loadWorkspaces());
     }
 
     async _loadWorkspaces() {
@@ -36,7 +34,7 @@ export class CreateProjectModal extends Component {
             this.state.workspaces = workspaceService.workspaces;
             // Auto-select first workspace if only one exists
             if (this.state.workspaces.length === 1) {
-                this.state.workspaceId = String(this.state.workspaces[0].id);
+                this.state.workspaceId = this.state.workspaces[0].id;
             }
         } catch (err) {
             console.error("CreateProjectModal: failed to load workspaces:", err);
@@ -56,7 +54,7 @@ export class CreateProjectModal extends Component {
     }
 
     onWorkspaceChange(ev) {
-        this.state.workspaceId = ev.target.value;
+        this.state.workspaceId = ev.target.value ? parseInt(ev.target.value, 10) : null;
         this.state.error = null;
     }
 
@@ -82,8 +80,7 @@ export class CreateProjectModal extends Component {
         this.state.error = null;
 
         try {
-            const workspaceId = parseInt(this.state.workspaceId, 10);
-            const result = await supportService.createProject(workspaceId, {
+            const result = await supportService.createProject(this.state.workspaceId, {
                 name,
                 description: this.state.description.trim(),
             });

--- a/src/static/src/paas/components/modal/CreateProjectModal.js
+++ b/src/static/src/paas/components/modal/CreateProjectModal.js
@@ -1,0 +1,97 @@
+/** @odoo-module **/
+import { Component, useState, onMounted } from "@odoo/owl";
+import { WoowButton } from "../button/WoowButton";
+import { WoowIcon } from "../icon/WoowIcon";
+import { supportService } from "../../services/support_service";
+import { workspaceService } from "../../services/workspace_service";
+
+export class CreateProjectModal extends Component {
+    static template = "woow_paas_platform.CreateProjectModal";
+    static components = { WoowButton, WoowIcon };
+    static props = {
+        onClose: { type: Function },
+        onCreated: { type: Function },
+    };
+
+    setup() {
+        this.state = useState({
+            name: "",
+            description: "",
+            workspaceId: "",
+            loading: false,
+            error: null,
+            workspaces: [],
+            workspacesLoading: true,
+        });
+
+        onMounted(async () => {
+            await this._loadWorkspaces();
+        });
+    }
+
+    async _loadWorkspaces() {
+        this.state.workspacesLoading = true;
+        try {
+            await workspaceService.fetchWorkspaces();
+            this.state.workspaces = workspaceService.workspaces;
+            // Auto-select first workspace if only one exists
+            if (this.state.workspaces.length === 1) {
+                this.state.workspaceId = String(this.state.workspaces[0].id);
+            }
+        } catch (err) {
+            this.state.error = "Failed to load workspaces";
+        } finally {
+            this.state.workspacesLoading = false;
+        }
+    }
+
+    onNameInput(ev) {
+        this.state.name = ev.target.value;
+        this.state.error = null;
+    }
+
+    onDescriptionInput(ev) {
+        this.state.description = ev.target.value;
+    }
+
+    onWorkspaceChange(ev) {
+        this.state.workspaceId = ev.target.value;
+        this.state.error = null;
+    }
+
+    onBackdropClick(ev) {
+        if (ev.target === ev.currentTarget) {
+            this.props.onClose();
+        }
+    }
+
+    async onSubmit() {
+        const name = this.state.name.trim();
+        if (!name) {
+            this.state.error = "Project name is required";
+            return;
+        }
+
+        if (!this.state.workspaceId) {
+            this.state.error = "Please select a workspace";
+            return;
+        }
+
+        this.state.loading = true;
+        this.state.error = null;
+
+        const workspaceId = parseInt(this.state.workspaceId, 10);
+        const result = await supportService.createProject(workspaceId, {
+            name,
+            description: this.state.description.trim(),
+        });
+
+        this.state.loading = false;
+
+        if (result.success) {
+            this.props.onCreated(result.data);
+        } else {
+            this.state.error = result.error || "Failed to create project";
+        }
+    }
+}

--- a/src/static/src/paas/components/modal/CreateProjectModal.js
+++ b/src/static/src/paas/components/modal/CreateProjectModal.js
@@ -39,6 +39,7 @@ export class CreateProjectModal extends Component {
                 this.state.workspaceId = String(this.state.workspaces[0].id);
             }
         } catch (err) {
+            console.error("CreateProjectModal: failed to load workspaces:", err);
             this.state.error = "Failed to load workspaces";
         } finally {
             this.state.workspacesLoading = false;
@@ -80,18 +81,23 @@ export class CreateProjectModal extends Component {
         this.state.loading = true;
         this.state.error = null;
 
-        const workspaceId = parseInt(this.state.workspaceId, 10);
-        const result = await supportService.createProject(workspaceId, {
-            name,
-            description: this.state.description.trim(),
-        });
+        try {
+            const workspaceId = parseInt(this.state.workspaceId, 10);
+            const result = await supportService.createProject(workspaceId, {
+                name,
+                description: this.state.description.trim(),
+            });
 
-        this.state.loading = false;
-
-        if (result.success) {
-            this.props.onCreated(result.data);
-        } else {
-            this.state.error = result.error || "Failed to create project";
+            if (result.success) {
+                this.props.onCreated(result.data);
+            } else {
+                this.state.error = result.error || "Failed to create project";
+            }
+        } catch (err) {
+            console.error("CreateProjectModal: submit failed:", err);
+            this.state.error = "An unexpected error occurred. Please try again.";
+        } finally {
+            this.state.loading = false;
         }
     }
 }

--- a/src/static/src/paas/components/modal/CreateProjectModal.xml
+++ b/src/static/src/paas/components/modal/CreateProjectModal.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="woow_paas_platform.CreateProjectModal">
+        <div class="o_woow_modal_backdrop" t-on-click="onBackdropClick">
+            <div class="o_woow_modal">
+                <div class="o_woow_modal_header">
+                    <h2>Create New Project</h2>
+                    <button class="o_woow_modal_close" t-on-click="props.onClose">
+                        <WoowIcon name="'close'" size="20"/>
+                    </button>
+                </div>
+
+                <div class="o_woow_modal_body">
+                    <div class="o_woow_form_group">
+                        <label for="project_name">Project Name</label>
+                        <input
+                            type="text"
+                            id="project_name"
+                            class="o_woow_input"
+                            placeholder="e.g., Customer Portal Redesign"
+                            t-att-value="state.name"
+                            t-on-input="onNameInput"
+                            t-att-disabled="state.loading"
+                        />
+                    </div>
+
+                    <div class="o_woow_form_group">
+                        <label for="project_description">Description (optional)</label>
+                        <textarea
+                            id="project_description"
+                            class="o_woow_textarea"
+                            placeholder="Describe your project..."
+                            rows="3"
+                            t-att-value="state.description"
+                            t-on-input="onDescriptionInput"
+                            t-att-disabled="state.loading"
+                        />
+                    </div>
+
+                    <div class="o_woow_form_group">
+                        <label for="project_workspace">Workspace</label>
+                        <t t-if="state.workspacesLoading">
+                            <div class="o_woow_input o_woow_select_loading">
+                                <WoowIcon name="'sync'" size="16" class="'o_woow_spin'"/>
+                                <span>Loading workspaces...</span>
+                            </div>
+                        </t>
+                        <t t-else="">
+                            <select
+                                id="project_workspace"
+                                class="o_woow_input o_woow_select"
+                                t-att-value="state.workspaceId"
+                                t-on-change="onWorkspaceChange"
+                                t-att-disabled="state.loading"
+                            >
+                                <option value="">Select a workspace...</option>
+                                <t t-foreach="state.workspaces" t-as="ws" t-key="ws.id">
+                                    <option t-att-value="ws.id" t-att-selected="String(ws.id) === state.workspaceId" t-esc="ws.name"/>
+                                </t>
+                            </select>
+                        </t>
+                    </div>
+
+                    <div t-if="state.error" class="o_woow_error_message">
+                        <WoowIcon name="'error'" size="16"/>
+                        <span t-esc="state.error"/>
+                    </div>
+                </div>
+
+                <div class="o_woow_modal_footer">
+                    <WoowButton variant="'ghost'" size="'md'" onClick="props.onClose" disabled="state.loading">
+                        Cancel
+                    </WoowButton>
+                    <WoowButton variant="'primary'" size="'md'" onClick.bind="onSubmit" disabled="state.loading || state.workspacesLoading">
+                        <t t-if="state.loading">
+                            <WoowIcon name="'sync'" size="16" class="'o_woow_spin'"/>
+                            Creating...
+                        </t>
+                        <t t-else="">
+                            Create Project
+                        </t>
+                    </WoowButton>
+                </div>
+            </div>
+        </div>
+    </t>
+</templates>

--- a/src/static/src/paas/components/modal/CreateProjectModal.xml
+++ b/src/static/src/paas/components/modal/CreateProjectModal.xml
@@ -55,7 +55,7 @@
                             >
                                 <option value="">Select a workspace...</option>
                                 <t t-foreach="state.workspaces" t-as="ws" t-key="ws.id">
-                                    <option t-att-value="ws.id" t-att-selected="'' + ws.id === state.workspaceId" t-esc="ws.name"/>
+                                    <option t-att-value="ws.id" t-att-selected="ws.id === state.workspaceId" t-esc="ws.name"/>
                                 </t>
                             </select>
                         </t>

--- a/src/static/src/paas/components/modal/CreateProjectModal.xml
+++ b/src/static/src/paas/components/modal/CreateProjectModal.xml
@@ -55,7 +55,7 @@
                             >
                                 <option value="">Select a workspace...</option>
                                 <t t-foreach="state.workspaces" t-as="ws" t-key="ws.id">
-                                    <option t-att-value="ws.id" t-att-selected="String(ws.id) === state.workspaceId" t-esc="ws.name"/>
+                                    <option t-att-value="ws.id" t-att-selected="'' + ws.id === state.workspaceId" t-esc="ws.name"/>
                                 </t>
                             </select>
                         </t>

--- a/src/static/src/paas/components/modal/CreateTaskModal.js
+++ b/src/static/src/paas/components/modal/CreateTaskModal.js
@@ -1,0 +1,107 @@
+/** @odoo-module **/
+import { Component, useState, onMounted } from "@odoo/owl";
+import { WoowButton } from "../button/WoowButton";
+import { WoowIcon } from "../icon/WoowIcon";
+import { supportService } from "../../services/support_service";
+
+export class CreateTaskModal extends Component {
+    static template = "woow_paas_platform.CreateTaskModal";
+    static components = { WoowButton, WoowIcon };
+    static props = {
+        onClose: { type: Function },
+        onCreated: { type: Function },
+        defaultProjectId: { type: Number, optional: true },
+    };
+
+    setup() {
+        this.supportService = supportService;
+        this.state = useState({
+            name: "",
+            description: "",
+            projectId: this.props.defaultProjectId || null,
+            priority: "0",
+            deadline: "",
+            loading: false,
+            error: null,
+        });
+
+        onMounted(async () => {
+            await supportService.fetchAllProjects();
+        });
+    }
+
+    onNameInput(ev) {
+        this.state.name = ev.target.value;
+        this.state.error = null;
+    }
+
+    onDescriptionInput(ev) {
+        this.state.description = ev.target.value;
+    }
+
+    onProjectChange(ev) {
+        this.state.projectId = ev.target.value ? parseInt(ev.target.value, 10) : null;
+        this.state.error = null;
+    }
+
+    onPriorityChange(ev) {
+        this.state.priority = ev.target.value;
+    }
+
+    onDeadlineInput(ev) {
+        this.state.deadline = ev.target.value;
+    }
+
+    onBackdropClick(ev) {
+        if (ev.target === ev.currentTarget) {
+            this.props.onClose();
+        }
+    }
+
+    async onSubmit() {
+        const name = this.state.name.trim();
+        if (!name) {
+            this.state.error = "Task name is required";
+            return;
+        }
+
+        if (!this.state.projectId) {
+            this.state.error = "Please select a project";
+            return;
+        }
+
+        const project = supportService.projects.find(
+            (p) => p.id === this.state.projectId
+        );
+        const workspaceId = project?.workspace_id;
+
+        if (!workspaceId) {
+            this.state.error = "Selected project has no associated workspace";
+            return;
+        }
+
+        this.state.loading = true;
+        this.state.error = null;
+
+        const data = {
+            name,
+            description: this.state.description.trim(),
+            project_id: this.state.projectId,
+            priority: this.state.priority,
+        };
+
+        if (this.state.deadline) {
+            data.date_deadline = this.state.deadline;
+        }
+
+        const result = await supportService.createTask(workspaceId, data);
+
+        this.state.loading = false;
+
+        if (result.success) {
+            this.props.onCreated(result.data);
+        } else {
+            this.state.error = result.error || "Failed to create task";
+        }
+    }
+}

--- a/src/static/src/paas/components/modal/CreateTaskModal.js
+++ b/src/static/src/paas/components/modal/CreateTaskModal.js
@@ -22,6 +22,7 @@ export class CreateTaskModal extends Component {
             priority: "0",
             deadline: "",
             loading: false,
+            projectsLoading: true,
             error: null,
         });
 
@@ -29,11 +30,14 @@ export class CreateTaskModal extends Component {
     }
 
     async _loadProjects() {
+        this.state.projectsLoading = true;
         try {
             await supportService.fetchAllProjects();
         } catch (err) {
             console.error("CreateTaskModal: failed to load projects:", err);
             this.state.error = "Failed to load projects";
+        } finally {
+            this.state.projectsLoading = false;
         }
     }
 

--- a/src/static/src/paas/components/modal/CreateTaskModal.js
+++ b/src/static/src/paas/components/modal/CreateTaskModal.js
@@ -25,9 +25,16 @@ export class CreateTaskModal extends Component {
             error: null,
         });
 
-        onMounted(async () => {
+        onMounted(() => this._loadProjects());
+    }
+
+    async _loadProjects() {
+        try {
             await supportService.fetchAllProjects();
-        });
+        } catch (err) {
+            console.error("CreateTaskModal: failed to load projects:", err);
+            this.state.error = "Failed to load projects";
+        }
     }
 
     onNameInput(ev) {
@@ -83,25 +90,30 @@ export class CreateTaskModal extends Component {
         this.state.loading = true;
         this.state.error = null;
 
-        const data = {
-            name,
-            description: this.state.description.trim(),
-            project_id: this.state.projectId,
-            priority: this.state.priority,
-        };
+        try {
+            const data = {
+                name,
+                description: this.state.description.trim(),
+                project_id: this.state.projectId,
+                priority: this.state.priority,
+            };
 
-        if (this.state.deadline) {
-            data.date_deadline = this.state.deadline;
-        }
+            if (this.state.deadline) {
+                data.date_deadline = this.state.deadline;
+            }
 
-        const result = await supportService.createTask(workspaceId, data);
+            const result = await supportService.createTask(workspaceId, data);
 
-        this.state.loading = false;
-
-        if (result.success) {
-            this.props.onCreated(result.data);
-        } else {
-            this.state.error = result.error || "Failed to create task";
+            if (result.success) {
+                this.props.onCreated(result.data);
+            } else {
+                this.state.error = result.error || "Failed to create task";
+            }
+        } catch (err) {
+            console.error("CreateTaskModal: submit failed:", err);
+            this.state.error = "An unexpected error occurred. Please try again.";
+        } finally {
+            this.state.loading = false;
         }
     }
 }

--- a/src/static/src/paas/components/modal/CreateTaskModal.js
+++ b/src/static/src/paas/components/modal/CreateTaskModal.js
@@ -14,7 +14,7 @@ export class CreateTaskModal extends Component {
     };
 
     setup() {
-        this.supportService = supportService;
+        this.supportService = useState(supportService);
         this.state = useState({
             name: "",
             description: "",

--- a/src/static/src/paas/components/modal/CreateTaskModal.xml
+++ b/src/static/src/paas/components/modal/CreateTaskModal.xml
@@ -39,21 +39,29 @@
 
                     <div class="o_woow_form_group">
                         <label for="task_project">Project</label>
-                        <select
-                            id="task_project"
-                            class="o_woow_input"
-                            t-on-change="onProjectChange"
-                            t-att-disabled="state.loading"
-                        >
-                            <option value="">-- Select a project --</option>
-                            <t t-foreach="supportService.projects" t-as="project" t-key="project.id">
-                                <option
-                                    t-att-value="project.id"
-                                    t-att-selected="state.projectId === project.id"
-                                    t-esc="project.name"
-                                />
-                            </t>
-                        </select>
+                        <t t-if="state.projectsLoading">
+                            <div class="o_woow_input o_woow_select_loading">
+                                <WoowIcon name="'sync'" size="16" class="'o_woow_spin'"/>
+                                <span>Loading projects...</span>
+                            </div>
+                        </t>
+                        <t t-else="">
+                            <select
+                                id="task_project"
+                                class="o_woow_input"
+                                t-on-change="onProjectChange"
+                                t-att-disabled="state.loading"
+                            >
+                                <option value="">Select a project...</option>
+                                <t t-foreach="supportService.projects" t-as="project" t-key="project.id">
+                                    <option
+                                        t-att-value="project.id"
+                                        t-att-selected="state.projectId === project.id"
+                                        t-esc="project.name"
+                                    />
+                                </t>
+                            </select>
+                        </t>
                     </div>
 
                     <div class="o_woow_form_group">

--- a/src/static/src/paas/components/modal/CreateTaskModal.xml
+++ b/src/static/src/paas/components/modal/CreateTaskModal.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="woow_paas_platform.CreateTaskModal">
+        <div class="o_woow_modal_backdrop" t-on-click="onBackdropClick">
+            <div class="o_woow_modal">
+                <div class="o_woow_modal_header">
+                    <h2>Create New Task</h2>
+                    <button class="o_woow_modal_close" t-on-click="props.onClose">
+                        <WoowIcon name="'close'" size="20"/>
+                    </button>
+                </div>
+
+                <div class="o_woow_modal_body">
+                    <div class="o_woow_form_group">
+                        <label for="task_name">Task Name</label>
+                        <input
+                            type="text"
+                            id="task_name"
+                            class="o_woow_input"
+                            placeholder="e.g., Fix login page layout"
+                            t-att-value="state.name"
+                            t-on-input="onNameInput"
+                            t-att-disabled="state.loading"
+                        />
+                    </div>
+
+                    <div class="o_woow_form_group">
+                        <label for="task_description">Description (optional)</label>
+                        <textarea
+                            id="task_description"
+                            class="o_woow_textarea"
+                            placeholder="Describe the task..."
+                            rows="3"
+                            t-att-value="state.description"
+                            t-on-input="onDescriptionInput"
+                            t-att-disabled="state.loading"
+                        />
+                    </div>
+
+                    <div class="o_woow_form_group">
+                        <label for="task_project">Project</label>
+                        <select
+                            id="task_project"
+                            class="o_woow_input"
+                            t-on-change="onProjectChange"
+                            t-att-disabled="state.loading"
+                        >
+                            <option value="">-- Select a project --</option>
+                            <t t-foreach="supportService.projects" t-as="project" t-key="project.id">
+                                <option
+                                    t-att-value="project.id"
+                                    t-att-selected="state.projectId === project.id"
+                                    t-esc="project.name"
+                                />
+                            </t>
+                        </select>
+                    </div>
+
+                    <div class="o_woow_form_group">
+                        <label for="task_priority">Priority</label>
+                        <select
+                            id="task_priority"
+                            class="o_woow_input"
+                            t-on-change="onPriorityChange"
+                            t-att-disabled="state.loading"
+                        >
+                            <option value="0" t-att-selected="state.priority === '0'">Low</option>
+                            <option value="1" t-att-selected="state.priority === '1'">Normal</option>
+                            <option value="2" t-att-selected="state.priority === '2'">High</option>
+                            <option value="3" t-att-selected="state.priority === '3'">Urgent</option>
+                        </select>
+                    </div>
+
+                    <div class="o_woow_form_group">
+                        <label for="task_deadline">Deadline (optional)</label>
+                        <input
+                            type="date"
+                            id="task_deadline"
+                            class="o_woow_input"
+                            t-att-value="state.deadline"
+                            t-on-input="onDeadlineInput"
+                            t-att-disabled="state.loading"
+                        />
+                    </div>
+
+                    <div t-if="state.error" class="o_woow_error_message">
+                        <WoowIcon name="'error'" size="16"/>
+                        <span t-esc="state.error"/>
+                    </div>
+                </div>
+
+                <div class="o_woow_modal_footer">
+                    <WoowButton variant="'ghost'" size="'md'" onClick="props.onClose" disabled="state.loading">
+                        Cancel
+                    </WoowButton>
+                    <WoowButton variant="'primary'" size="'md'" onClick.bind="onSubmit" disabled="state.loading">
+                        <t t-if="state.loading">
+                            <WoowIcon name="'sync'" size="16" class="'o_woow_spin'"/>
+                            Creating...
+                        </t>
+                        <t t-else="">
+                            Create Task
+                        </t>
+                    </WoowButton>
+                </div>
+            </div>
+        </div>
+    </t>
+</templates>

--- a/src/static/src/paas/pages/support-projects/SupportProjectsPage.js
+++ b/src/static/src/paas/pages/support-projects/SupportProjectsPage.js
@@ -22,9 +22,7 @@ export class SupportProjectsPage extends Component {
             viewMode: "grid",
             showCreateModal: false,
         });
-        onMounted(async () => {
-            await this._loadProjects();
-        });
+        onMounted(() => this._loadProjects());
     }
 
     async _loadProjects() {

--- a/src/static/src/paas/pages/support-projects/SupportProjectsPage.js
+++ b/src/static/src/paas/pages/support-projects/SupportProjectsPage.js
@@ -31,7 +31,7 @@ export class SupportProjectsPage extends Component {
         try {
             await supportService.fetchAllProjects();
         } catch (err) {
-            console.warn("Failed to load support projects:", err);
+            console.error("Failed to load support projects:", err);
         }
     }
 

--- a/src/static/src/paas/pages/support-projects/SupportProjectsPage.js
+++ b/src/static/src/paas/pages/support-projects/SupportProjectsPage.js
@@ -3,13 +3,14 @@ import { Component, useState, onMounted } from "@odoo/owl";
 import { WoowCard } from "../../components/card/WoowCard";
 import { WoowIcon } from "../../components/icon/WoowIcon";
 import { WoowButton } from "../../components/button/WoowButton";
+import { CreateProjectModal } from "../../components/modal/CreateProjectModal";
 import { router } from "../../core/router";
 import { supportService } from "../../services/support_service";
 import { formatDate, getInitials } from "../../services/utils";
 
 export class SupportProjectsPage extends Component {
     static template = "woow_paas_platform.SupportProjectsPage";
-    static components = { WoowCard, WoowIcon, WoowButton };
+    static components = { WoowCard, WoowIcon, WoowButton, CreateProjectModal };
     static props = {};
 
     setup() {
@@ -19,6 +20,7 @@ export class SupportProjectsPage extends Component {
             searchQuery: "",
             statusFilter: "all",
             viewMode: "grid",
+            showCreateModal: false,
         });
         onMounted(async () => {
             await this._loadProjects();
@@ -131,6 +133,19 @@ export class SupportProjectsPage extends Component {
 
     onViewModeChange(mode) {
         this.state.viewMode = mode;
+    }
+
+    openCreateModal() {
+        this.state.showCreateModal = true;
+    }
+
+    closeCreateModal() {
+        this.state.showCreateModal = false;
+    }
+
+    async onProjectCreated(project) {
+        this.state.showCreateModal = false;
+        await this._loadProjects();
     }
 
     navigateToProject(projectId) {

--- a/src/static/src/paas/pages/support-projects/SupportProjectsPage.xml
+++ b/src/static/src/paas/pages/support-projects/SupportProjectsPage.xml
@@ -176,13 +176,12 @@
                     </WoowCard>
                 </div>
             </t>
-        </div>
-
             <!-- Create Project Modal -->
             <CreateProjectModal
                 t-if="state.showCreateModal"
                 onClose.bind="closeCreateModal"
                 onCreated.bind="onProjectCreated"
             />
+        </div>
     </t>
 </templates>

--- a/src/static/src/paas/pages/support-projects/SupportProjectsPage.xml
+++ b/src/static/src/paas/pages/support-projects/SupportProjectsPage.xml
@@ -13,6 +13,12 @@
                         <p>Browse and manage support projects across your workspaces.</p>
                     </div>
                 </div>
+                <div class="o_woow_sp_header_right">
+                    <WoowButton variant="'primary'" size="'sm'" onClick.bind="openCreateModal">
+                        <WoowIcon name="'add'" size="18"/>
+                        New Project
+                    </WoowButton>
+                </div>
             </div>
 
             <!-- Toolbar: Search + Filters + View Toggle -->
@@ -160,12 +166,23 @@
                                 </WoowButton>
                             </t>
                             <t t-else="">
-                                <p>There are no support projects available yet. Projects will appear here once they are created.</p>
+                                <p>There are no support projects available yet. Create your first project to get started.</p>
+                                <WoowButton variant="'primary'" size="'sm'" onClick.bind="openCreateModal">
+                                    <WoowIcon name="'add'" size="18"/>
+                                    Create your first project
+                                </WoowButton>
                             </t>
                         </div>
                     </WoowCard>
                 </div>
             </t>
         </div>
+
+            <!-- Create Project Modal -->
+            <CreateProjectModal
+                t-if="state.showCreateModal"
+                onClose.bind="closeCreateModal"
+                onCreated.bind="onProjectCreated"
+            />
     </t>
 </templates>

--- a/src/static/src/paas/pages/support-tasks/SupportTasksPage.js
+++ b/src/static/src/paas/pages/support-tasks/SupportTasksPage.js
@@ -3,13 +3,14 @@ import { Component, useState, onMounted } from "@odoo/owl";
 import { WoowCard } from "../../components/card/WoowCard";
 import { WoowIcon } from "../../components/icon/WoowIcon";
 import { WoowButton } from "../../components/button/WoowButton";
+import { CreateTaskModal } from "../../components/modal/CreateTaskModal";
 import { router } from "../../core/router";
 import { supportService } from "../../services/support_service";
 import { formatDate, getInitials, getPriorityStars } from "../../services/utils";
 
 export class SupportTasksPage extends Component {
     static template = "woow_paas_platform.SupportTasksPage";
-    static components = { WoowCard, WoowIcon, WoowButton };
+    static components = { WoowCard, WoowIcon, WoowButton, CreateTaskModal };
     static props = {};
 
     setup() {
@@ -18,6 +19,7 @@ export class SupportTasksPage extends Component {
             loading: true,
             searchQuery: "",
             filterMode: "my",
+            showCreateModal: false,
         });
         this.supportService = useState(supportService);
 
@@ -86,6 +88,19 @@ export class SupportTasksPage extends Component {
     async onFilterToggle(mode) {
         if (this.state.filterMode === mode) return;
         this.state.filterMode = mode;
+        await this._loadTasks();
+    }
+
+    openCreateModal() {
+        this.state.showCreateModal = true;
+    }
+
+    closeCreateModal() {
+        this.state.showCreateModal = false;
+    }
+
+    async onTaskCreated(task) {
+        this.state.showCreateModal = false;
         await this._loadTasks();
     }
 

--- a/src/static/src/paas/pages/support-tasks/SupportTasksPage.js
+++ b/src/static/src/paas/pages/support-tasks/SupportTasksPage.js
@@ -23,9 +23,7 @@ export class SupportTasksPage extends Component {
         });
         this.supportService = useState(supportService);
 
-        onMounted(async () => {
-            await this._loadTasks();
-        });
+        onMounted(() => this._loadTasks());
     }
 
     async _loadTasks() {

--- a/src/static/src/paas/pages/support-tasks/SupportTasksPage.js
+++ b/src/static/src/paas/pages/support-tasks/SupportTasksPage.js
@@ -37,7 +37,7 @@ export class SupportTasksPage extends Component {
             }
             await supportService.fetchAllTasks(filters);
         } catch (err) {
-            console.warn("Failed to load tasks:", err);
+            console.error("Failed to load tasks:", err);
         } finally {
             this.state.loading = false;
         }

--- a/src/static/src/paas/pages/support-tasks/SupportTasksPage.xml
+++ b/src/static/src/paas/pages/support-tasks/SupportTasksPage.xml
@@ -14,7 +14,6 @@
                     </div>
                 </div>
                 <div class="o_woow_support_tasks_header_right">
-                    <!-- New Task Button -->
                     <WoowButton variant="'primary'" size="'sm'" onClick.bind="openCreateModal">
                         <WoowIcon name="'add'" size="16"/>
                         New Task

--- a/src/static/src/paas/pages/support-tasks/SupportTasksPage.xml
+++ b/src/static/src/paas/pages/support-tasks/SupportTasksPage.xml
@@ -14,6 +14,11 @@
                     </div>
                 </div>
                 <div class="o_woow_support_tasks_header_right">
+                    <!-- New Task Button -->
+                    <WoowButton variant="'primary'" size="'sm'" onClick.bind="openCreateModal">
+                        <WoowIcon name="'add'" size="16"/>
+                        New Task
+                    </WoowButton>
                     <!-- Search -->
                     <div class="o_woow_search_box">
                         <WoowIcon name="'search'" size="18"/>
@@ -67,6 +72,10 @@
                     </t>
                     <t t-else="">
                         <p>No tasks in your workspaces yet. Create a project and add tasks to get started.</p>
+                        <WoowButton variant="'primary'" size="'md'" onClick.bind="openCreateModal">
+                            <WoowIcon name="'add'" size="16"/>
+                            Create your first task
+                        </WoowButton>
                     </t>
                 </div>
             </t>
@@ -143,6 +152,12 @@
                     </t>
                 </div>
             </t>
+            <!-- Create Task Modal -->
+            <CreateTaskModal
+                t-if="state.showCreateModal"
+                onClose.bind="closeCreateModal"
+                onCreated.bind="onTaskCreated"
+            />
         </div>
     </t>
 </templates>

--- a/src/static/src/paas/services/support_service.js
+++ b/src/static/src/paas/services/support_service.js
@@ -199,6 +199,34 @@ export const supportService = reactive({
     },
 
     /**
+     * Create a new project in a workspace
+     * @param {number} workspaceId - Workspace ID
+     * @param {Object} data - Project creation data
+     * @param {string} data.name - Project name
+     * @param {string} [data.description] - Project description
+     * @returns {Promise<{success: boolean, data?: ProjectData, error?: string}>}
+     */
+    async createProject(workspaceId, data) {
+        this.operationLoading.createProject = true;
+        try {
+            const result = await jsonRpc(`/api/support/projects/${workspaceId}`, {
+                action: "create",
+                ...data,
+            });
+            if (result.success) {
+                this.projects = [result.data, ...this.projects];
+                return { success: true, data: result.data };
+            } else {
+                return { success: false, error: result.error };
+            }
+        } catch (err) {
+            return { success: false, error: err.message };
+        } finally {
+            this.operationLoading.createProject = false;
+        }
+    },
+
+    /**
      * Create a new task in a workspace project
      * @param {number} workspaceId - Workspace ID
      * @param {Object} data - Task creation data


### PR DESCRIPTION
## Summary
- 新增 `CreateProjectModal` 和 `CreateTaskModal` 元件，支援在 Support 頁面直接新增專案與任務
- 新增 `createProject()` API 方法到 `support_service.js`
- 修正 Modal 元件的 runtime errors（props 驗證與事件處理）
- 新增 support-crud-ui PRD 與 epic 規劃（含 4 個 tasks）

## Test plan
- [ ] 開啟 SupportProjectsPage，點擊新增按鈕驗證 CreateProjectModal 正常彈出
- [ ] 填寫表單並送出，確認專案建立成功
- [ ] 開啟 SupportTasksPage，點擊新增按鈕驗證 CreateTaskModal 正常彈出
- [ ] 填寫任務表單並送出，確認任務建立成功
- [ ] 驗證 Modal 關閉後頁面正常刷新資料