### PR TITLE
feat: cloud service config restriction with structured HelmValueForm

### DIFF
--- a/src/controllers/paas.py
+++ b/src/controllers/paas.py
@@ -1067,10 +1067,9 @@ class PaasController(Controller):
         helm_namespace = f"paas-ws-{workspace.id}"
 
         # Filter user values to only allowed keys, then merge with defaults
+        # Note: silently filter on create (frontend may send defaults alongside user values)
         default_values = json.loads(template.helm_default_values) if template.helm_default_values else {}
-        filtered_user_values, rejected_keys = self._filter_allowed_helm_values(values, template)
-        if rejected_keys:
-            return {'success': False, 'error': f'Unauthorized configuration keys: {", ".join(rejected_keys)}'}
+        filtered_user_values, _rejected = self._filter_allowed_helm_values(values, template)
         merged_values = {**default_values, **filtered_user_values}
 
         try:

--- a/src/controllers/paas.py
+++ b/src/controllers/paas.py
@@ -1218,6 +1218,7 @@ class PaasController(Controller):
             release_info = client.upgrade_release(
                 namespace=service.helm_namespace,
                 release_name=service.helm_release_name,
+                chart=service.template_id.helm_chart_name,
                 values=merged_values,
                 version=version,
             )

--- a/src/data/cloud_app_templates.xml
+++ b/src/data/cloud_app_templates.xml
@@ -130,7 +130,8 @@
                 "postgresql": {"enabled": true, "architecture": "standalone", "auth": {"username":
                 "bn_odoo", "database": "bitnami_odoo"}, "image": {"registry":
                 "docker.io", "repository": "bitnamilegacy/postgresql", "tag": "17.6.0-debian-12-r4"}},
-                "persistence": {"enabled": true, "size": "10Gi"}}</field>
+                "persistence": {"enabled": true, "size": "10Gi"},
+                "updateStrategy": {"type": "Recreate"}}</field>
             <field name="helm_value_specs">{"required": [{"key": "odooEmail", "label": "Administrator Email", "type": "text", "default": "user@example.com"}, {"key": "odooPassword", "label": "Administrator Password", "type": "password"}], "optional": [{"key": "loadDemoData", "label": "Load Demo Data", "type": "boolean", "default": false}]}</field>
 
             <!-- Service Configuration -->

--- a/src/static/src/paas/pages/service/tabs/ConfigurationTab.xml
+++ b/src/static/src/paas/pages/service/tabs/ConfigurationTab.xml
@@ -85,20 +85,35 @@
                     <div class="o_woow_config_editor">
                         <div class="o_woow_editor_hint">
                             <WoowIcon name="'info'" size="16"/>
-                            <span>Edit the JSON configuration below. Changes will trigger a service upgrade.</span>
+                            <span>Modify configuration values below. Changes will trigger a service upgrade.</span>
                         </div>
-                        <textarea
-                            class="o_woow_config_textarea"
-                            t-att-value="editedValuesJson"
-                            t-on-input="onValuesChange"
-                            rows="20"
-                            spellcheck="false"/>
-                        <div class="o_woow_editor_footer">
-                            <span t-if="hasChanges" class="o_woow_changes_indicator">
-                                <WoowIcon name="'edit'" size="14"/>
-                                Unsaved changes
-                            </span>
-                        </div>
+                        <HelmValueForm
+                            specs="helmValueSpecs"
+                            values="state.editedValues"
+                            onUpdate.bind="onHelmValueUpdate"
+                            showAdvanced="state.showAdvanced"
+                            errors="state.errors"
+                        />
+                        <t t-if="hasOptionalSettings">
+                            <button
+                                type="button"
+                                class="o_woow_advanced_toggle"
+                                t-on-click="toggleAdvanced"
+                            >
+                                <WoowIcon
+                                    t-if="state.showAdvanced"
+                                    name="'expand_less'"
+                                    size="18"
+                                />
+                                <WoowIcon
+                                    t-else=""
+                                    name="'expand_more'"
+                                    size="18"
+                                />
+                                <t t-if="state.showAdvanced">Hide Advanced Settings</t>
+                                <t t-else="">Show Advanced Settings</t>
+                            </button>
+                        </t>
                     </div>
                 </WoowCard>
             </t>

--- a/src/static/src/paas/pages/service/tabs/ConfigurationTab.xml
+++ b/src/static/src/paas/pages/service/tabs/ConfigurationTab.xml
@@ -58,21 +58,19 @@
             <!-- View Mode -->
             <t t-if="!state.editing">
                 <WoowCard class="'o_woow_config_card'">
-                    <t t-if="flattenedValues.length === 0">
+                    <t t-if="allSpecs.length === 0">
                         <div class="o_woow_config_empty">
                             <WoowIcon name="'settings'" size="32"/>
-                            <p>No configuration values set.</p>
-                            <p class="o_woow_hint">Click "Edit Configuration" to add values.</p>
+                            <p>No configurable settings for this service.</p>
                         </div>
                     </t>
                     <t t-else="">
                         <div class="o_woow_config_list">
-                            <t t-foreach="flattenedValues" t-as="item" t-key="item.key">
+                            <t t-foreach="allSpecs" t-as="spec" t-key="spec.key">
                                 <div class="o_woow_config_item">
-                                    <span class="o_woow_config_key" t-esc="item.key"/>
-                                    <span t-att-class="'o_woow_config_value' + (item.isSecret ? ' o_woow_secret' : '')">
-                                        <t t-if="item.isSecret">********</t>
-                                        <t t-else="" t-esc="item.value"/>
+                                    <span class="o_woow_config_key" t-esc="spec.label || spec.key"/>
+                                    <span t-att-class="'o_woow_config_value' + (spec.type === 'password' ? ' o_woow_secret' : '')">
+                                        <t t-esc="formatSpecValue(spec)"/>
                                     </span>
                                 </div>
                             </t>


### PR DESCRIPTION
## 摘要
- 將 ConfigurationTab 從原始 JSON textarea 重構為基於 `helm_value_specs` 的結構化 HelmValueForm
- 新增後端驗證機制，拒絕未授權的 helm value keys（僅允許使用者可設定的欄位）
- 修復 `upgrade_release` 缺少 chart reference 導致升級失敗的問題
- 設定 Odoo template 的 `updateStrategy` 為 `Recreate`，避免 ResourceQuota 限制下滾動更新失敗

## 變更內容（4 檔案，7 commits）
- `src/controllers/paas.py` — 新增 `_filter_allowed_helm_values()`、擴充 `_format_service()` 回傳 `helm_value_specs`、修復 upgrade 缺少 chart 參數
- `src/data/cloud_app_templates.xml` — Odoo template 新增 `updateStrategy: Recreate`
- `src/static/src/paas/pages/service/tabs/ConfigurationTab.js` — 以 HelmValueForm 取代 textarea，結構化唯讀顯示
- `src/static/src/paas/pages/service/tabs/ConfigurationTab.xml` — 更新模板，依 spec 定義渲染欄位

## 測試計畫
- [x] E2E：透過 Marketplace UI 部署 Odoo 服務
- [x] E2E：ConfigurationTab 唯讀模式僅顯示 spec 定義的欄位
- [x] E2E：密碼欄位顯示為 `********`
- [x] E2E：編輯模式顯示 HelmValueForm 並帶入正確值
- [x] E2E：Save Changes 成功升級 K8s 中的 Helm release
- [x] E2E：更新後的值反映在 Pod 環境變數中
- [x] E2E：後端拒絕未授權的基礎設施 keys